### PR TITLE
Using blessed terminal length function for string length

### DIFF
--- a/enlighten/_counter.py
+++ b/enlighten/_counter.py
@@ -653,7 +653,11 @@ class Counter(BaseCounter):
             rtn = self.bar_format.format(**fields)
 
             # Format the bar
-            barWidth = width - len(rtn) + self.offset + 3  # 3 is for the bar placeholder
+            if self.offset:
+                # Keeping offset support for backwards compatibility
+                barWidth = width - len(rtn) + self.offset + 3  # 3 is for the bar placeholder
+            else:
+                barWidth = width - self.manager.term.length(rtn) + 3  # 3 is for the bar placeholder
             complete = barWidth * percentage
             barLen = int(complete)
             barText = u''
@@ -676,7 +680,11 @@ class Counter(BaseCounter):
         # Otherwise return a counter
         fields['fill'] = u'{0}'
         rtn = self.counter_format.format(**fields)
-        return rtn.format(u' ' * (width - len(rtn) + self.offset + 3))
+        if self.offset:
+            ret = rtn.format(u' ' * (width - len(rtn) + self.offset + 3))
+        else:
+            ret = rtn.format(u' ' * (width - self.manager.term.length(rtn) + 3))
+        return ret
 
     def refresh(self, flush=True, elapsed=None):
         """

--- a/enlighten/_counter.py
+++ b/enlighten/_counter.py
@@ -579,8 +579,7 @@ class Counter(BaseCounter):
 
         return subcounters, fields
 
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-locals,too-many-branches
     def format(self, width=None, elapsed=None):
         """
         Args:
@@ -654,11 +653,12 @@ class Counter(BaseCounter):
             rtn = self.bar_format.format(**fields)
 
             # Format the bar
-            if self.offset is not None:
-                # Keeping offset support for backwards compatibility
-                barWidth = width - len(rtn) + self.offset + 3  # 3 is for the bar placeholder
-            else:
+            if self.offset is None:
                 barWidth = width - self.manager.term.length(rtn) + 3  # 3 is for the bar placeholder
+            else:
+                # Offset was explicitly given
+                barWidth = width - len(rtn) + self.offset + 3  # 3 is for the bar placeholder
+
             complete = barWidth * percentage
             barLen = int(complete)
             barText = u''
@@ -681,10 +681,13 @@ class Counter(BaseCounter):
         # Otherwise return a counter
         fields['fill'] = u'{0}'
         rtn = self.counter_format.format(**fields)
-        if self.offset is not None:
-            ret = rtn.format(u' ' * (width - len(rtn) + self.offset + 3))
-        else:
+
+        if self.offset is None:
             ret = rtn.format(u' ' * (width - self.manager.term.length(rtn) + 3))
+        else:
+            # Offset was explicitly given
+            ret = rtn.format(u' ' * (width - len(rtn) + self.offset + 3))
+
         return ret
 
     def refresh(self, flush=True, elapsed=None):

--- a/enlighten/_counter.py
+++ b/enlighten/_counter.py
@@ -580,6 +580,7 @@ class Counter(BaseCounter):
         return subcounters, fields
 
     # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches
     def format(self, width=None, elapsed=None):
         """
         Args:

--- a/enlighten/_counter.py
+++ b/enlighten/_counter.py
@@ -462,7 +462,7 @@ class Counter(BaseCounter):
         self.enabled = kwargs.get('enabled', True)
         self.leave = kwargs.get('leave', True)
         self.min_delta = kwargs.get('min_delta', 0.1)
-        self.offset = kwargs.get('offset', 0)
+        self.offset = kwargs.get('offset', None)
         self.series = kwargs.get('series', SERIES_STD)
         self.total = kwargs.get('total', None)
         self.unit = kwargs.get('unit', None)
@@ -653,7 +653,7 @@ class Counter(BaseCounter):
             rtn = self.bar_format.format(**fields)
 
             # Format the bar
-            if self.offset:
+            if self.offset is not None:
                 # Keeping offset support for backwards compatibility
                 barWidth = width - len(rtn) + self.offset + 3  # 3 is for the bar placeholder
             else:
@@ -680,7 +680,7 @@ class Counter(BaseCounter):
         # Otherwise return a counter
         fields['fill'] = u'{0}'
         rtn = self.counter_format.format(**fields)
-        if self.offset:
+        if self.offset is not None:
             ret = rtn.format(u' ' * (width - len(rtn) + self.offset + 3))
         else:
             ret = rtn.format(u' ' * (width - self.manager.term.length(rtn) + 3))

--- a/examples/multicolored.py
+++ b/examples/multicolored.py
@@ -94,10 +94,8 @@ def run_tests(manager, tests=100):
                  u'E:' + terminal.yellow(u'{count_1:{len_total}d}') + u' ' + \
                  u'[{elapsed}<{eta}, {rate:.2f}{unit_pad}{unit}/s]'
 
-    offset = len(terminal.green('')) + len(terminal.red('')) + len(terminal.yellow(''))
-
-    with manager.counter(total=tests, desc='Testing', unit='tests', offset=offset,
-                         color='green', bar_format=bar_format) as success:
+    with manager.counter(total=tests, desc='Testing', unit='tests', color='green',
+                         bar_format=bar_format) as success:
         errors = success.add_subcounter('yellow')
         failures = success.add_subcounter('red')
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -486,6 +486,33 @@ class TestCounter(TestCase):
         self.assertEqual(len(formatted), 80)
         self.assertRegex(formatted, r'Test 100%\|' u'█+' + r'\| 0/0 \[00:0\d<00:00, 0.00 ticks/s\]')
 
+    def test_colored(self):
+        """
+        Color sequences should not be counted as characters when formatting
+        (Only if offset is not set)
+        """
+
+        barFormat = u'{desc}{desc_pad}{percentage:3.0f}%|{bar}|{count:{len_total}d}/{total:d} ' + \
+                    u'[{elapsed}<{eta}, {rate:.2f}{unit_pad}{unit}/s]'
+        blueBarFormat = self.manager.term.blue(barFormat)
+
+        ctr = self.manager.counter(stream=self.tty.stdout, total=10, desc='Test',
+                                   unit='ticks', count=10, bar_format=barFormat)
+        formatted1 = ctr.format(width=80)
+        self.assertEqual(len(formatted1), 80)
+        self.assertEqual(self.manager.term.length(formatted1), 80)
+        barLen1 = formatted1.count(u'█')
+
+        offset = len(self.manager.term.blue(''))
+        ctr = self.manager.counter(stream=self.tty.stdout, total=10, desc='Test',
+                                   unit='ticks', count=10, bar_format=blueBarFormat)
+        formatted2 = ctr.format(width=80)
+        self.assertEqual(len(formatted2), 80 + offset)
+        self.assertEqual(self.manager.term.length(formatted2), 80)
+        barLen2 = formatted2.count(u'█')
+
+        self.assertTrue(barLen2 == barLen1)
+
     def test_offset(self):
         """
         Offset reduces count of printable characters when formatting
@@ -496,7 +523,7 @@ class TestCounter(TestCase):
         barFormat = self.manager.term.blue(barFormat)
 
         ctr = self.manager.counter(stream=self.tty.stdout, total=10, desc='Test',
-                                   unit='ticks', count=10, bar_format=barFormat)
+                                   unit='ticks', count=10, bar_format=barFormat, offset=0)
         formatted1 = ctr.format(width=80)
         self.assertEqual(len(formatted1), 80)
         barLen1 = formatted1.count(u'█')
@@ -511,7 +538,7 @@ class TestCounter(TestCase):
         self.assertTrue(barLen2 == barLen1 + offset)
 
         # Test in counter format
-        ctr = self.manager.counter(stream=self.tty.stdout, total=10, count=50)
+        ctr = self.manager.counter(stream=self.tty.stdout, total=10, count=50, offset=0)
         formatted = ctr.format(width=80)
         self.assertEqual(len(formatted), 80)
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -486,21 +486,21 @@ class TestCounter(TestCase):
         self.assertEqual(len(formatted), 80)
         self.assertRegex(formatted, r'Test 100%\|' u'█+' + r'\| 0/0 \[00:0\d<00:00, 0.00 ticks/s\]')
 
-    def test_colored(self):
+    def test_auto_offset(self):
         """
-        Color sequences should not be counted as characters when formatting
-        (Only if offset is not set)
+        If offset is not specified, terminal codes should be automatically ignored
+        when calculating bar length
         """
 
         barFormat = u'{desc}{desc_pad}{percentage:3.0f}%|{bar}|{count:{len_total}d}/{total:d} ' + \
                     u'[{elapsed}<{eta}, {rate:.2f}{unit_pad}{unit}/s]'
         blueBarFormat = self.manager.term.blue(barFormat)
+        self.assertNotEqual(len(barFormat), len(blueBarFormat))
 
         ctr = self.manager.counter(stream=self.tty.stdout, total=10, desc='Test',
                                    unit='ticks', count=10, bar_format=barFormat)
         formatted1 = ctr.format(width=80)
         self.assertEqual(len(formatted1), 80)
-        self.assertEqual(self.manager.term.length(formatted1), 80)
         barLen1 = formatted1.count(u'█')
 
         offset = len(self.manager.term.blue(''))
@@ -508,7 +508,6 @@ class TestCounter(TestCase):
                                    unit='ticks', count=10, bar_format=blueBarFormat)
         formatted2 = ctr.format(width=80)
         self.assertEqual(len(formatted2), 80 + offset)
-        self.assertEqual(self.manager.term.length(formatted2), 80)
         barLen2 = formatted2.count(u'█')
 
         self.assertTrue(barLen2 == barLen1)


### PR DESCRIPTION
Hi Avram,

blessed terminal has a [length](https://blessed.readthedocs.io/en/latest/api.html#blessed.terminal.Terminal.length) function that takes into account sequences and special chars.

This means there's no need to use the `offset` value used by the `multicolored.py` example.

Really, offset should not needed anymore, but I left it there for backwards compatibility. It was not documented but was still part of an example, so I'll let you decide if it should be removed.