### PR TITLE
Round down partial seconds

### DIFF
--- a/enlighten/_util.py
+++ b/enlighten/_util.py
@@ -1,6 +1,6 @@
 
 # -*- coding: utf-8 -*-
-# Copyright 2017 - 2022 Avram Lubkin, All Rights Reserved
+# Copyright 2017 - 2023 Avram Lubkin, All Rights Reserved
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -76,9 +76,9 @@ def format_time(seconds):
     """
 
     # Always do minutes and seconds in mm:ss format
-    minutes = seconds // 60
-    hours = minutes // 60
-    rtn = u'%02.0f:%02.0f' % (minutes % 60, seconds % 60)
+    minutes, seconds = divmod(round(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    rtn = u'%02d:%02d' % (minutes, seconds)
 
     #  Add hours if there are any
     if hours:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 - 2022 Avram Lubkin, All Rights Reserved
+# Copyright 2017 - 2023 Avram Lubkin, All Rights Reserved
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -29,10 +29,13 @@ class TestFormatTime(TestCase):
         self.assertEqual(format_time(0), '00:00')
         self.assertEqual(format_time(6), '00:06')
         self.assertEqual(format_time(42), '00:42')
+        self.assertEqual(format_time(48.2), '00:48')
+        self.assertEqual(format_time(52.6), '00:53')
 
     def test_minutes(self):
         """Verify minutes formatting"""
 
+        self.assertEqual(format_time(59.9), '01:00')
         self.assertEqual(format_time(60), '01:00')
         self.assertEqual(format_time(128), '02:08')
         self.assertEqual(format_time(1684), '28:04')


### PR DESCRIPTION
Previously, partial seconds could sometimes be rounded up by the formatter resulting in "XX:60" being displayed briefly. If we always round down first, we can avoid this.