### PR TITLE
docs: fix indentation in example

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -152,7 +152,7 @@ about valid colors.
 
     for num in range(100):
         time.sleep(0.1)  # Simulate work
-    counter.update()
+        counter.update()
 
 Additionally, any part of the progress bar can be colored using counter
 :ref:`formatting <counter_format>` and the


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix indentation of the code example in doc/examples.rst